### PR TITLE
Added lang attribute to html element for accessibility

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
### What I did:

- Added a `lang="en"` attribute to the `<html>` element on `mistakes.html`.

### Why I did it:

- The page was missing a document language, which is an accessibility issue.
- Screen readers and other assistive technologies rely on the lang attribute to determine pronunciation rules and provide the correct experience for users.

### WCAG Reference:

- [WCAG 2.1 - Understanding SC 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page)

### How I found the issue:

- While reviewing the HTML, I noticed the `<html>` tag didn't include a `lang` attribute.
- I confirmed this against the WCAG guideline that requires defining a default language for all documents.

### What I learned:

- Even small details like `lang="en"` make a big difference for accessibility.
- Tools like screen readers may mispronounce words or switch voices if the language is not declared.