### PR TITLE
Improved text contrast by removing text-slate-400 class

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -19,7 +19,7 @@
     >
       <div class="flex flex-col gap-4 md:ml-6">
         <p class="text-6xl md:text-left text-center">What's for dessert?</p>
-        <p class="italic text-slate-400">
+        <p class="italic">
           This page has several mistakes which could impact both its
           accessibility and usability! Check out the README in the
           <a
@@ -41,7 +41,7 @@
         <h2 class="text-4xl border-b-4 mb-4 border-pink-400">
           History of desserts
         </h2>
-        <p class="italic mb-4 text-slate-400">
+        <p class="italic mb-4">
           Dessert foods have a rich history, spanning from ancient civilizations
           to modern times. From the ancient Egyptians' honey and fruit
           concoctions, to the intricate pastries of France and gelato
@@ -87,7 +87,7 @@
         <h2 class="text-4xl border-b-4 mb-4 border-pink-400">
           Types of desserts
         </h2>
-        <p class="italic mb-4 text-slate-400">
+        <p class="italic mb-4">
           Desserts come in various forms and flavors, ranging from sweet to
           savory. Whether it's a classic apple pie or a creamy cheesecake,
           desserts are irresistible delights that are enjoyed by people of all
@@ -159,7 +159,7 @@
         <h2 class="text-4xl border-b-4 mb-4 border-pink-400">
           Gallery of dessert disasters
         </h2>
-        <p class="italic mb-4 text-slate-400">
+        <p class="italic mb-4">
           Dessert doesn't always go sweetly! Check out these hilarious mishaps,
           and then maybe even try to make some of your own!
         </p>


### PR DESCRIPTION
### What I did:

- Adjusted the text color on elements with low contrast by removing the `text-slate-400` class to improve readability on the page.

### Why I did it:

- Some text on `mistakes.html` had insufficient contrast against its background, making it hard for users with visual impairments or color vision deficiencies to read.
- Improving contrast ensures the content is perceivable and accessible to everyone.

### WCAG Reference:

- [WCAG SC 1.4.3: Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum)

### How I found the issue:

- Reviewed the page visually and used a contrast checker tool (like WebAIM Contrast Checker) to identify text with insufficient contrast.
- Confirmed that the color combinations did not meet the recommended 4.5:1 contrast ratio for normal text.

### What I learned:

- Even subtle color differences can make content unreadable for some users.
- Accessibility isn’t just about adding tags -- it’s about considering all aspects of perceivability, including color, size, and context.