### PR TITLE
Made anchor tag focus visible for better accessibility

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -175,7 +175,7 @@
               <a
                 class="underline text-fuchsia-800 hover:no-underline text-right mt-4"
                 href="https://www.pbs.org/food/recipes/cookie-monster-cupcakes/"
-                >Recipe</a
+                >Cookie monster cupcake recipe</a
               >
             </div>
           </li>
@@ -190,7 +190,7 @@
               <a
                 class="underline text-fuchsia-800 hover:no-underline text-right mt-4"
                 href="https://www.yummly.com/recipe/The-BEST-Chocolate-Chip-Cookies-2639812?prm-v1"
-                >Recipe</a
+                >Chocolate chip cookie recipe</a
               >
             </div>
           </li>
@@ -205,7 +205,7 @@
               <a
                 class="underline text-fuchsia-800 hover:no-underline text-right mt-4"
                 href="https://www.notonthehighstreet.com/honeywellbakes/product/teddy-bear-bun-baking-kit?referredBy=search"
-                >Recipe</a
+                >Pull-apart sweet buns recipe</a
               >
             </div>
           </li>

--- a/mistakes.html
+++ b/mistakes.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.tailwindcss.com"></script>
     <title>Learn about desserts</title>
-    <style>
-      a:focus {
-        outline: visible;
-      }
-    </style>
   </head>
   <body
     class="bg-repeat object-contain bg-opacity-20 bg-[url('https://ideasparalaclase.com/wp-content/uploads/2017/08/Black-and-white-Polka-Dot-Seamless-Pattern-Paint-Stain-Abstract-600x600.jpeg')]"

--- a/mistakes.html
+++ b/mistakes.html
@@ -7,7 +7,7 @@
     <title>Learn about desserts</title>
     <style>
       a:focus {
-        outline: none;
+        outline: visible;
       }
     </style>
   </head>


### PR DESCRIPTION
### **What I did:**
- Changed the focus property on <a> tags from none to visible.
- Ensured keyboard users can clearly see which link is focused.
 
### **Why I did it:**
- Previously, keyboard users could not see which link was active, making navigation difficult.
- Visible focus indicators help users who rely on keyboards or have attention/memory limitations.
 - Improves accessibility and aligns with WCAG guidelines.

### **WCAG Reference:**
- [WCAG SC 2.4.7: Focus Visible (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible)

### **How I found the issue:**
- Tested page using keyboard navigation (Tab key).
- Noticed no visual indicator appeared on focused links.

### **What I learned:**
- Even small style changes like focus visibility can significantly improve accessibility.
- Proper focus styling is crucial for users navigating without a mouse.