### PR TITLE
Replace div with ordered list for better accessibility

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -108,13 +108,13 @@
           In order from most popular to least popular, CherryOnTech did a poll
           and found that the following cakes were the most popular:
         </p>
-        <div class="flex flex-col my-4">
-          <p>1. Chocolate</p>
-          <p>2. Red velvet</p>
-          <p>3. Banana</p>
-          <p>4. Vanilla</p>
-          <p>5. Pistachio</p>
-        </div>
+        <ol class="list-decimal list-inside my-4">
+          <li>Chocolate</li>
+          <li>Red velvet</li>
+          <li>Banana</li>
+          <li>Vanilla</li>
+          <li>Pistachio</li>
+        </ol>
 
         <h3 class="text-2xl mb-4 mt-6 border-b-2 border-pink-200">Cookies</h3>
         <p>


### PR DESCRIPTION
### What I did:

- Replace `<div>` with ordered list `<ol>`

<img width="170" height="137" alt="image" src="https://github.com/user-attachments/assets/d0f14374-2817-41cd-86a5-af0c75ca9be7" />

### Why I did it:

- The list looked like a list but wasn't marked up as a list.
- > When markup is used that visually formats items as a list but does not indicate the list relationship, users may have difficulty in navigating the information. [H48: Using ol, ul and dl for lists or groups of links | WAI | W3C](https://www.w3.org/WAI/WCAG21/Techniques/html/H48)

### WCAG Reference:

- [Understanding Success Criterion 1.3.1: Info and Relationships | WAI | W3C](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)

### How I found the issue:

- Checked whether all lists on the page were correctly marked up.

### What I learned:

- It is important to match the visual appearance with the HTML structure.