### PR TITLE
Change paragraph to heading for better semantic structure

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -18,7 +18,7 @@
       class="bg-opacity-95 min-h-1/3 bg-blue-100 flex flex-col justify-evenly items-center flex-col-reverse md:flex-row p-6 gap-6 md:gap-12"
     >
       <div class="flex flex-col gap-4 md:ml-6">
-        <p class="text-6xl md:text-left text-center">What's for dessert?</p>
+        <h1 class="text-6xl md:text-left text-center">What's for dessert?</h1>
         <p class="italic text-slate-400">
           This page has several mistakes which could impact both its
           accessibility and usability! Check out the README in the


### PR DESCRIPTION
### What I did:

- Replace `<p>` with `<h1>`

<img width="622" height="175" alt="image" src="https://github.com/user-attachments/assets/f86ea80a-ce22-4ae4-b24a-f00852e78386" />

### Why I did it:

- The element looked like a heading but wasn't marked up as a heading.

### WCAG Reference:

- [Understanding Success Criterion 1.3.1: Info and Relationships | WAI | W3C](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)

### How I found the issue:

- Checked whether all headings on the page were correctly marked up.

### What I learned:

- It is important to match the visual appearance with the HTML structure.