### PR TITLE
Remove style tag to make focus visible.

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.tailwindcss.com"></script>
     <title>Learn about desserts</title>
-    <style>
-      a:focus {
-        outline: visible;
-      }
-    </style>
   </head>
   <body
     class="bg-repeat object-contain bg-opacity-20 bg-[url('https://ideasparalaclase.com/wp-content/uploads/2017/08/Black-and-white-Polka-Dot-Seamless-Pattern-Paint-Stain-Abstract-600x600.jpeg')]"

--- a/mistakes.html
+++ b/mistakes.html
@@ -7,7 +7,7 @@
     <title>Learn about desserts</title>
     <style>
       a:focus {
-        outline: none;
+        outline: visible;
       }
     </style>
   </head>


### PR DESCRIPTION
### **What I did:**
- Removed the <style> tag that hid the focus outline.
- Made sure links show a clear focus when using the keyboard.

### **Why I did it:**
- Before, keyboard users could not see which link was active.
- Focus outlines make navigation easier and follow accessibility rules.

### **WCAG Reference:**
[WCAG SC 2.4.7: Focus Visible (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible)

### **How I found the issue:**
- Tested the page with the Tab key.
- Saw that links had no visible focus.

### **What I learned:**
- Small changes, like showing focus, can improve accessibility.
- Focus outlines are important for users without a mouse.